### PR TITLE
Update index.js to handle local files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ function isPDF (url) {
   return new Promise((resolve, reject) => {
     if (url.startsWith(`file://${pdfjsPath}?file=`)) {
       resolve(false)
-    } else if (url.match(/^file:\/\//i)) {
-      const fileUrl = url.replace(/^file:\/\//i, '')
+    } else if (url.match(/^file:\/\/\//i)) {
+      const fileUrl = url.replace(/^file:\/\/\//i, '')
       const buffer = readChunk.sync(fileUrl, 0, 262)
       const ft = fileType(buffer)
 


### PR DESCRIPTION
I was able to get the PDFWindow to work perfectly for online (http/https) files, but when attempting to open a local file I got a prompt to save instead of opening. After looking through the code, i noticed there was a "/" missing from the local file:/// portion of the Promise.