### PR TITLE
Ability to use data URLs to display locally generated PDFs

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function isData (url) {
 
 function getMimeOfData (url) {
   const fileUrl = url.replace(/^data:/i, '')
-  const end = url.indexOf(';')
-  return url.substr(0, end)
+  const end = fileUrl.indexOf(';')
+  return fileUrl.substr(0, end)
 }
 
 function hasPdfExtension (url) {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,16 @@ function getMimeOfFile (url) {
   return ft ? ft.mime : null
 }
 
+function isData (url) {
+  return url.match(/^data:/i)
+}
+
+function getMimeOfData (url) {
+  const fileUrl = url.replace(/^data:/i, '')
+  const end = url.indexOf(';')
+  return url.substr(0, end)
+}
+
 function hasPdfExtension (url) {
   return url.match(/\.pdf$/i)
 }
@@ -37,6 +47,8 @@ function isPDF (url) {
       resolve(false)
     } else if (isFile(url)) {
       resolve(getMimeOfFile(url) === 'application/pdf')
+    } else if (isData(url)) {
+      resolve(getMimeOfData(url) === 'application/pdf')
     } else if (hasPdfExtension(url)) {
       resolve(true)
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf-window",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "view PDF files in electron browser windows",
   "main": "index.js",
   "scripts": {
@@ -18,14 +18,14 @@
     "url": "git://github.com/gerhardberger/electron-pdf-window.git"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
-    "file-type": "^3.9.0",
-    "got": "^7.1.0",
+    "deep-extend": "^0.6.0",
+    "file-type": "^10.9.0",
+    "got": "^9.6.0",
     "is-electron-renderer": "^2.0.1",
-    "read-chunk": "^2.0.0"
+    "read-chunk": "^3.1.0"
   },
   "devDependencies": {
-    "standard": "^8.6.0"
+    "standard": "^12.0.1"
   },
   "author": "@gellerthegyi",
   "license": "MIT"


### PR DESCRIPTION
Example, use pdfMake.js to generate PDFs, and stream them to the viewer window. This appears to bypass the cross-platform issues involved with using file URLs. Tested on Windows 10.

```
In renderer thread, generate a PDF and send the data URL via IPC
    const {ipcRenderer} = require('electron');
    pdfMake.create(pdf).getDataUrl(function(result) {
        ipcRenderer.send('asynchronous-message', result);
    });

In main thread, works as normal:
    var pdfWindow = null;
    const {ipcMain} = require('electron')
    ipcMain.on('asynchronous-message', (event, url) => {
        pdfWindow = new PDFWindow({
            width: 1024,
            height: 768,
          });
        log.info('Opening a PDFWindow');
        pdfWindow.loadURL(url);
    });
```
