### PR TITLE
URL with parameters does not get processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class PDFWindow extends BrowserWindow {
       if (isit) {
         super.loadURL(`file://${
           path.join(__dirname, 'pdfjs', 'web', 'viewer.html')}?file=${
-            decodeURIComponent(url)}`, options)
+            encodeURIComponent(url)}`, options)
       } else {
         super.loadURL(url, options)
       }


### PR DESCRIPTION
pdf.js viewer requires the url to be encoded rather than decoded