### PR TITLE
New Patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/gerhardberger/electron-pdf-window.git"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.6.0",
     "file-type": "^3.9.0",
     "got": "^7.1.0",
     "is-electron-renderer": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "deep-extend": "^0.6.0",
     "file-type": "^3.9.0",
-    "got": "^7.1.0",
+    "got": "11",
     "is-electron-renderer": "^2.0.1",
     "read-chunk": "^2.0.0"
   },


### PR DESCRIPTION
After some tweaks, I still got some errors on newer electron versions.

So i checked out the dependences, and confirmed that some dependences are outdated.

The most important was the "got" dependence, this dependence was throwing an error "HTTP TRAILER IS NOT ALLOWED" in the newer electron versions, so I updated to a version that already corrected this issue.

The other dependence, "deep-extend" got some security alerts, so I upgraded to the latest version.

Hope this helps.